### PR TITLE
Better error reporting when config file is not found

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,5 +6,6 @@ David Halter (@davidhalter) <davidhalter88@gmail.com>
 Code Contributors
 =================
 
-
 Note: (@user) means a github user name.
+
+Danilo Bargen (@dbrgn) <github@dbrgn.ch>

--- a/depl/__init__.py
+++ b/depl/__init__.py
@@ -30,10 +30,10 @@ def main():
     try:
         c = config.Config(args['--config'], args['<host>'], args['--pool'])
     except IOError:
-        sys.stderr.write("Couldn't find config file.")
+        sys.stderr.write("Couldn't find depl config file ({0}).\n".format(args['--config']))
         sys.exit(1)
     except config.ValidationError as e:
-        sys.stderr.write("Config file is invalid: " + e.message)
+        sys.stderr.write("Config file is invalid: {0}\n".format(e.message))
         sys.exit(2)
 
     for pool in c.pools:


### PR DESCRIPTION
- Missing newlines
- Mention name of config file in error message
